### PR TITLE
Fix undefined index notice

### DIFF
--- a/app/code/community/RatePAY/Ratepaypayment/Helper/Data.php
+++ b/app/code/community/RatePAY/Ratepaypayment/Helper/Data.php
@@ -354,9 +354,9 @@ class RatePAY_Ratepaypayment_Helper_Data extends Mage_Core_Helper_Abstract
     
     private function _setBankDataSession($data, $code)
     {
-        if($data[$code . '_iban']) {
+        if(isset($data[$code . '_iban']) && $data[$code . '_iban']) {
             Mage::getSingleton('core/session')->setIban($data[$code . '_iban']);
-            if($data[$code . '_bic']) {
+            if(isset($data[$code . '_bic']) && $data[$code . '_bic']) {
                 Mage::getSingleton('core/session')->setBic($data[$code . '_bic']);
             }
         } else {
@@ -617,4 +617,3 @@ class RatePAY_Ratepaypayment_Helper_Data extends Mage_Core_Helper_Abstract
         echo '</table>';
     }
 }
-

--- a/app/code/community/RatePAY/Ratepaypayment/Helper/Mapping.php
+++ b/app/code/community/RatePAY/Ratepaypayment/Helper/Mapping.php
@@ -83,6 +83,14 @@ class RatePAY_Ratepaypayment_Helper_Mapping extends Mage_Core_Helper_Abstract
                     $articleDiscountAmount = $articleDiscountAmount + $item->getDiscountAmount();
                 }
 
+                // set default values for unitPrice and totalPrice if they are not set
+                if(!isset($article['unitPrice'])) {
+                  $article['unitPrice'] = '';
+                }
+                if(!isset($article['totalPrice'])) {
+                  $article['totalPrice'] = '';
+                }
+
                 $articles[] = $article;
                 if ($item->getDiscountAmount() > 0) { // only for sort reason
                     $articles[] = $discount;
@@ -141,6 +149,14 @@ class RatePAY_Ratepaypayment_Helper_Mapping extends Mage_Core_Helper_Abstract
                     $discount['taxPercent'] = $article['taxPercent'];
                 }
                 $discount['discountId'] = 'SHIPPING';
+            }
+
+            // set default values for unitPrice and totalPrice if they are not set
+            if(!isset($article['unitPrice'])) {
+              $article['unitPrice'] = '';
+            }
+            if(!isset($article['totalPrice'])) {
+              $article['totalPrice'] = '';
             }
 
             $articles[] = $article;

--- a/app/code/community/RatePAY/Ratepaypayment/Helper/Payment.php
+++ b/app/code/community/RatePAY/Ratepaypayment/Helper/Payment.php
@@ -162,9 +162,9 @@ class RatePAY_Ratepaypayment_Helper_Payment extends Mage_Core_Helper_Abstract
         foreach (Mage::helper('ratepaypayment/mapping')->getArticles($creditmemo) as $article) {
             ($article['articleNumber'] == 'DISCOUNT') ? $condition = $article['articleName'] : $condition = $article['articleNumber'];
             $creditmemoItems[$condition]['quantity'] = $article['quantity'];
-            $creditmemoItems[$condition]['unitPrice'] = $article['unitPrice'];
+            $creditmemoItems[$condition]['unitPrice'] = (isset($article['unitPrice']) ? $article['unitPrice'] : '');
             $creditmemoItems[$condition]['unitPriceGross'] = $article['unitPriceGross'];
-            $creditmemoItems[$condition]['totalPrice'] = $article['totalPrice'];
+            $creditmemoItems[$condition]['totalPrice'] = (isset($article['totalPrice']) ? $article['totalPrice'] : '');
             $creditmemoItems[$condition]['tax'] = $article['tax'];
             $creditmemoItems[$condition]['taxPercent'] = $article['taxPercent'];
             $creditmemoItems[$condition]['articleNumber'] = $article['articleNumber'];
@@ -191,9 +191,9 @@ class RatePAY_Ratepaypayment_Helper_Payment extends Mage_Core_Helper_Abstract
         foreach ($orderItems as $orderItem) {
             $tempArray = array();
             $tempArray['quantity'] = $orderItem['quantity'];
-            $tempArray['unitPrice'] = $orderItem['unitPrice'];
+            $tempArray['unitPrice'] = (isset($orderItem['unitPrice']) ? $orderItem['unitPrice'] : '');
             $tempArray['unitPriceGross'] = $orderItem['unitPriceGross'];
-            $tempArray['totalPrice'] = $orderItem['totalPrice'];
+            $tempArray['totalPrice'] = (isset($orderItem['totalPrice']) ? $orderItem['totalPrice'] : '');
             $tempArray['tax'] = $orderItem['tax'];
             $tempArray['taxPercent'] = !isset($orderItem['taxPercent']) ? 0 : $orderItem['taxPercent'];
             $tempArray['articleNumber'] = $orderItem['articleNumber'];
@@ -332,4 +332,3 @@ class RatePAY_Ratepaypayment_Helper_Payment extends Mage_Core_Helper_Abstract
         return $this->_productsToMethods[$id];
     }
 }
-


### PR DESCRIPTION
If error_reporting is enabled for notices, some helpers throw 'undefined index' notices when they want to access an undefined index of an array.
The pull request fixes this problem by checking for these indexes or set some default values for them.